### PR TITLE
Save CPC args in .json file

### DIFF
--- a/cpc/train.py
+++ b/cpc/train.py
@@ -347,6 +347,8 @@ def main(args):
         if not os.path.isdir(args.pathCheckpoint):
             os.mkdir(args.pathCheckpoint)
         args.pathCheckpoint = os.path.join(args.pathCheckpoint, "checkpoint")
+        with open(args.pathCheckpoint + "_args.json", 'w') as file:
+            json.dump(vars(args), file, indent=2)
 
     scheduler = None
     if args.schedulerStep > 0:


### PR DESCRIPTION
Hi there,

Some users of the ZeroSpeech baseline complained that the _args.json file wasn't saved.
It blocks subsequent parts of the pipeline : resume training of the CPC model, training K-means, etc.

This PR should fix the issue :)

Cheers! 